### PR TITLE
Hotfix/time dependent tests

### DIFF
--- a/src/components/__tests__/__snapshots__/header.js.snap
+++ b/src/components/__tests__/__snapshots__/header.js.snap
@@ -23,7 +23,7 @@ exports[`Header renders correctly 1`] = `
     </li>
     <li>
       <a
-        href="/dynamic-route/1578686364540"
+        href="/dynamic-route/1482363367071"
       >
         Dynamic route example
       </a>

--- a/src/components/__tests__/header.js
+++ b/src/components/__tests__/header.js
@@ -3,6 +3,16 @@ import renderer from "react-test-renderer"
 
 import Header from "../header"
 
+let _nowFn
+beforeEach(() => {
+  _nowFn = Date.now
+  Date.now = jest.fn(() => 1482363367071);
+})
+
+afterEach(() => {
+  Date.now = _nowFn
+})
+
 describe("Header", () => {
   it("renders correctly", () => {
     const tree = renderer.create(<Header />).toJSON()


### PR DESCRIPTION
# Why?
Our tests were dependent of time and jest snapshots never matched because our DOM expectancy used Date.now

# What?
This complements the `Header.js` example to use `beforeEach` and `afterEach`.

Maybe we can improve this by moving this code into a global-like hook