### PR TITLE
Reusable hooks example

### DIFF
--- a/src/components/pageComponents/example/exampleList/store.js
+++ b/src/components/pageComponents/example/exampleList/store.js
@@ -1,26 +1,30 @@
-import { useSelector, useDispatch } from 'react-redux'
-import addItemAction from 'actions/addItem'
-import fetchDataAction from 'actions/fetchData'
-import R, { pathOr } from 'ramda'
+import { useSelector } from 'react-redux'
+import { pathOr } from 'ramda'
+
+// Hooks
+import useItems from 'hooks/useItems'
+import useFetcher from 'hooks/useFetcher'
 
 export default () => {
-  const dispatch = useDispatch()
+  const { items, addItem } = useItems()
+  const fetcher = useFetcher()
 
-  const addItem = itemText => {
-    dispatch(addItemAction(itemText))
-  }
+  /*
+    "fetchRepos" and "repos" variables could be in a separate hook for reusability
+    Ex:
+      const { repos, fetchRepos } = useRepos()
+
+    ** use the existing hooks at "./src/hooks" as a reference 
+  */
+
   const fetchRepos = () => {
-    dispatch(
-      fetchDataAction({
-        dispatch, // <- I couldn't find any other way :/
-        key: 'repos',
-        url: 'https://api.github.com/users/paulpetone/repos',
-      })
-    )
+    fetcher({
+      key: 'repos',
+      url: 'https://api.github.com/users/paulpetone/repos',
+    })
   }
 
-  const items = useSelector(state => state.items)
-  const repos = useSelector(state => R.pathOr([], ['requests', 'repos'], state))
+  const repos = useSelector(state => pathOr([], ['requests', 'repos'], state))
 
   return {
     addItem,

--- a/src/hooks/useFetcher.js
+++ b/src/hooks/useFetcher.js
@@ -1,0 +1,16 @@
+import { useDispatch } from 'react-redux'
+
+// Actions
+import fetchDataAction from 'actions/fetchData'
+
+const useFetcher = () => {
+  const dispatch = useDispatch()
+
+  const fetcher = ({ key, url }) => {
+    dispatch(fetchDataAction({ dispatch, key, url }))
+  }
+
+  return fetcher
+}
+
+export default useFetcher

--- a/src/hooks/useFetcher.js
+++ b/src/hooks/useFetcher.js
@@ -4,13 +4,13 @@ import { useDispatch } from 'react-redux'
 import fetchDataAction from 'actions/fetchData'
 
 const useFetcher = () => {
-  const dispatch = useDispatch()
+	const dispatch = useDispatch()
 
-  const fetcher = ({ key, url }) => {
-    dispatch(fetchDataAction({ dispatch, key, url }))
-  }
+	const fetcher = ({ key, url }) => {
+		dispatch(fetchDataAction({ dispatch, key, url }))
+	}
 
-  return fetcher
+	return fetcher
 }
 
 export default useFetcher

--- a/src/hooks/useItems.js
+++ b/src/hooks/useItems.js
@@ -6,15 +6,15 @@ import addItemAction from 'actions/addItem'
 
 const useItems = () => {
 	const dispatch = useDispatch()
-	
-  const addItem = itemText => {
+
+	const addItem = itemText => {
 		if (itemText.length)
-    	dispatch(addItemAction(itemText))
-  }
+			dispatch(addItemAction(itemText))
+	}
 
 	const items = useSelector(state => state.items)
 
-  return {
+	return {
 		items,
 		addItem
 	}

--- a/src/hooks/useItems.js
+++ b/src/hooks/useItems.js
@@ -1,0 +1,23 @@
+import { useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
+
+// Actions
+import addItemAction from 'actions/addItem'
+
+const useItems = () => {
+	const dispatch = useDispatch()
+	
+  const addItem = itemText => {
+		if (itemText.length)
+    	dispatch(addItemAction(itemText))
+  }
+
+	const items = useSelector(state => state.items)
+
+  return {
+		items,
+		addItem
+	}
+}
+
+export default useItems


### PR DESCRIPTION
Instead of importing the dispatcher every time, you can create separate hooks with limited responsibility to avoid bloating the ```store.js``` files.

Also, I strongly recommend renaming every hook as "useNameOfTheHook". Read the reference below:

`Unlike a React component, a custom Hook doesn’t need to have a specific signature. We can decide what it takes as arguments, and what, if anything, it should return. In other words, it’s just like a normal function. Its name should always start with use so that you can tell at a glance that the rules of Hooks apply to it.`

Source: https://reactjs.org/docs/hooks-custom.html
